### PR TITLE
Increase max export area

### DIFF
--- a/tdei_uw.env
+++ b/tdei_uw.env
@@ -99,4 +99,4 @@ WS_SMTP_PASS=${WS_SMTP_PASS}
 WS_OSM_MAX_CHANGESET_ELEMENTS=100000000 # max features per import or save
 WS_OSM_MAX_UPLOAD_BYTES=1000000000 # max size of dataset uploads
 WS_OSM_MAX_EXPORT_NODES=100000000 # max number of nodes per requeset
-WS_OSM_MAX_EXPORT_AREA=1 # max area per request in square degrees
+WS_OSM_MAX_EXPORT_AREA=64800 # max area per request in square degrees


### PR DESCRIPTION
This change increases value of the config limit controlling the OSM API input validation for the `map` API call used to export a workspace to the area of the world in EPSG 4326.