### PR TITLE
Switch OSM proxy from lighttpd to nginx

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -105,13 +105,13 @@ services:
       - traefik.http.services.osm-log-proxy.loadbalancer.server.port=80
 
   osm-web:
-    image: rtsp/lighttpd:latest
+    image: nginx:stable-alpine
     depends_on:
       - osm-rails
       - osm-cgimap
     volumes:
-      - ./osm-web/lighttpd.conf:/etc/lighttpd/conf.d/06-osm.conf:ro
-      - ./osm-rails/public:/var/www/html:ro
+      - ./osm-web/nginx.conf:/etc/nginx/conf.d/default.conf:ro
+      - ./osm-rails/public:/usr/share/nginx/html:ro
     labels:
       - traefik.enable=true
       - traefik.http.routers.osm-web.rule=Host(`${WS_OSM_HOST}`)

--- a/osm-web/Dockerfile
+++ b/osm-web/Dockerfile
@@ -1,3 +1,3 @@
-FROM rtsp/lighttpd:latest
+FROM nginx:stable-alpine
 
-COPY lighttpd.conf /etc/lighttpd/conf.d/06-osm.conf
+COPY nginx.conf /etc/nginx/conf.d/default.conf

--- a/osm-web/lighttpd.conf
+++ b/osm-web/lighttpd.conf
@@ -2,6 +2,9 @@
 # This file is based on openstreetmap-cgimap's lighttpd configuration example:
 # https://github.com/zerebubuth/openstreetmap-cgimap/blob/master/lighttpd.conf
 #
+# We don't use lighttpd anymore. We'll keep this reference file for now. Nginx
+# replaced lighttpd, and a similar configuration exists in nginx.conf.
+#
 
 server.reject-expect-100-with-417 = "disable"
 

--- a/osm-web/nginx.conf
+++ b/osm-web/nginx.conf
@@ -1,0 +1,63 @@
+#
+# This file is based on openstreetmap-cgimap's lighttpd configuration example:
+# https://github.com/zerebubuth/openstreetmap-cgimap/blob/master/lighttpd.conf
+#
+
+# Resolve hostnames with Docker's internal DNS resolver:
+resolver 127.0.0.11 ipv6=off;
+
+upstream osm-rails-upstream {
+    keepalive 4;
+    server osm-rails:3000;
+}
+
+server {
+    listen 80;
+    server_name _;
+
+    set_real_ip_from 0.0.0.0/0;
+    real_ip_header X-Forwarded-For;
+
+    error_page 404 /dispatch.map;
+
+    location / {
+        if ($request_method = GET) {
+            rewrite ^/api/0\.6/map(\.(json|xml))?(\?(.*))?$ /dispatch.map break;
+            rewrite ^/api/0\.6/(node|way|relation)/[0-9]+(\.(json|xml))?$ /dispatch.map break;
+            rewrite ^/api/0\.6/(node|way|relation)/[0-9]+/history.*$ /dispatch.map break;
+            rewrite ^/api/0\.6/(node|way|relation)/[0-9]+/[0-9]+.*$ /dispatch.map break;
+            rewrite ^/api/0\.6/(node|way|relation)/[0-9]+/relations$ /dispatch.map break;
+            rewrite ^/api/0\.6/node/[0-9]+/ways$ /dispatch.map break;
+            rewrite ^/api/0\.6/(way|relation)/[0-9]+/full$ /dispatch.map break;
+            rewrite ^/api/0\.6/changeset/[0-9]+.*$ /dispatch.map break;
+            rewrite ^/api/0\.6/(nodes|ways|relations)(\?(.*))?$ /dispatch.map break;
+            rewrite ^/api/0\.6/changeset/[0-9]+/download$ /dispatch.map break;
+        }
+
+        if ($request_method = POST) {
+            rewrite ^/api/0\.6/changeset/[0-9]+/upload.*$ /dispatch.map break;
+        }
+
+        if ($request_method = PUT) {
+            rewrite ^/api/0\.6/changeset/[0-9]+/close.*$ /dispatch.map break;
+            rewrite ^/api/0\.6/changeset/[0-9]+$ /dispatch.map break;
+            rewrite ^/api/0\.6/changeset/create.*$ /dispatch.map break;
+        }
+
+        location ~ ^/(?!(dispatch\.map)) {
+            proxy_pass http://osm-rails-upstream;
+            proxy_set_header Host $host;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Remote-User $remote_user;
+        }
+    }
+
+    location ~ \.map$ {
+        fastcgi_pass osm-cgimap:8000;
+        include fastcgi_params;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        fastcgi_param CONNECT_TIMEOUT 0;
+    }
+}


### PR DESCRIPTION
This switches the OSM reverse proxy that routes requests to the Rails API and CGImap from lighttpd to nginx as preparation for several upcoming enhancements.