### PR TITLE
Increase OSM Rails proxy timeout

### DIFF
--- a/osm-web/nginx.conf
+++ b/osm-web/nginx.conf
@@ -88,6 +88,9 @@ server {
 
         proxy_pass http://osm-rails-upstream;
 
+        # Some map operations may take a bit longer:
+        proxy_read_timeout 3m;
+
         proxy_set_header Host $host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;


### PR DESCRIPTION
This avoids an occasional timeout for longer requests on the Rails side. We will need to spend more time to identify why these requests sometimes exhibit unusual latency.