### PR TITLE
Ignores tasking manager front-end

### DIFF
--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -133,23 +133,23 @@ services:
     image: ${WS_DOCKER_REGISTRY}/workspaces-osm-cgimap:${CODE_VERSION}
 
   # tasking manager
-  tasks-frontend:
-    image: ${WS_DOCKER_REGISTRY}/workspaces-tasks-frontend:${ENV}
-    build:
-      cache_from:
-        - type=registry,ref=${WS_DOCKER_REGISTRY}/workspaces-tasks-frontend:buildcache
-      cache_to:
-        - type=registry,ref=${WS_DOCKER_REGISTRY}/workspaces-tasks-frontend:buildcache,mode=max
-      context: tasking-manager
-      dockerfile: ./scripts/docker/Dockerfile.frontend
-      args:
-        TM_APP_API_URL: ${WS_TASKS_URL}
-        #TM_CONSUMER_KEY
-        #TM_CONSUMER_SECRET
+  # tasks-frontend:
+  #   image: ${WS_DOCKER_REGISTRY}/workspaces-tasks-frontend:${ENV}
+  #   build:
+  #     cache_from:
+  #       - type=registry,ref=${WS_DOCKER_REGISTRY}/workspaces-tasks-frontend:buildcache
+  #     cache_to:
+  #       - type=registry,ref=${WS_DOCKER_REGISTRY}/workspaces-tasks-frontend:buildcache,mode=max
+  #     context: tasking-manager
+  #     dockerfile: ./scripts/docker/Dockerfile.frontend
+  #     args:
+  #       TM_APP_API_URL: ${WS_TASKS_URL}
+  #       #TM_CONSUMER_KEY
+  #       #TM_CONSUMER_SECRET
 
-  tasks-frontend_tag:
-    extends: tasks-frontend
-    image: ${WS_DOCKER_REGISTRY}/workspaces-tasks-frontend:${CODE_VERSION}
+  # tasks-frontend_tag:
+  #   extends: tasks-frontend
+  #   image: ${WS_DOCKER_REGISTRY}/workspaces-tasks-frontend:${CODE_VERSION}
 
   # tasking manager
   tasks-backend:

--- a/docker-compose.deploy.yml
+++ b/docker-compose.deploy.yml
@@ -176,15 +176,15 @@ services:
       CGIMAP_MAP_AREA: ${WS_OSM_MAX_EXPORT_AREA}
 
   # tasking manager (*not* Workspaces)
-  tasks-frontend:
-    image: ${WS_DOCKER_REGISTRY}/workspaces-tasks-frontend:${WS_DOCKER_TAG}
-    restart: always
-    labels:
-      - traefik.enable=true
-      - traefik.http.routers.tasks-frontend.rule=Host(`${WS_TASKS_HOST}`)
-      - traefik.http.services.tasks-frontend.loadbalancer.server.port=80
-      - traefik.http.routers.tasks-frontend.entrypoints=websecure
-      - traefik.http.routers.tasks-frontend.tls.certresolver=myresolver
+  # tasks-frontend:
+  #   image: ${WS_DOCKER_REGISTRY}/workspaces-tasks-frontend:${WS_DOCKER_TAG}
+  #   restart: always
+  #   labels:
+  #     - traefik.enable=true
+  #     - traefik.http.routers.tasks-frontend.rule=Host(`${WS_TASKS_HOST}`)
+  #     - traefik.http.services.tasks-frontend.loadbalancer.server.port=80
+  #     - traefik.http.routers.tasks-frontend.entrypoints=websecure
+  #     - traefik.http.routers.tasks-frontend.tls.certresolver=myresolver
 
   tasks-backend:
     image: ${WS_DOCKER_REGISTRY}/workspaces-tasks-backend:${WS_DOCKER_TAG}


### PR DESCRIPTION
This pull request comments out the configuration for the `tasks-frontend` service in both the build and deploy Docker Compose files. This effectively disables the building and deployment of the `tasks-frontend` container as part of the workspace stack, while leaving the backend service (`tasks-backend`) untouched.

Service configuration changes:

* Commented out the `tasks-frontend` and `tasks-frontend_tag` service definitions in `docker-compose.build.yml`, preventing their build and inclusion in the build stack.
* Commented out the `tasks-frontend` service definition in `docker-compose.deploy.yml`, disabling its deployment and related Traefik routing.Ignores tasking manager front-end